### PR TITLE
Admin: Move ownership of `safe.js` to the menu team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,11 +2,11 @@
 * @xFrednet
 
 # Files owned by the data team
-/scripts/save.js @uu-semp/2025-data-team
 /scripts/vocabulary.js @uu-semp/2025-data-team
 /assets/vocabulary.json @uu-semp/2025-data-team
 
 # Files owned by the menu team
+/scripts/save.js @uu-semp/2025-menu-team
 /index.css @uu-semp/2025-menu-team
 /index.html @uu-semp/2025-menu-team
 /index.js @uu-semp/2025-menu-team

--- a/scripts/save.js
+++ b/scripts/save.js
@@ -1,5 +1,5 @@
 // ==============================================
-// Owned by the Data Team
+// Owned by the Menu Team
 // ==============================================
 
 // Provide functions to be used by other scripts


### PR DESCRIPTION
Hej @uu-semp/2025-menu-team,

I've decided to change the ownership of the `save.js` file to the menu team, since it seems to be more a frontend thing and you (the menu team) had good ideas how to expand it.

I've talked about this change with @Viv9000 during the technical meeting. If you, as the team, don't want to maintain it, you're welcome to move the ownership back to me, or just ping me. I'm happy to help/maintain it instead.

You're also allowed to expand the fields on the window object. So you could have a `window.stats` with all the methods like `window.stats.add_win(<game>)` and `window.stats.set_completion(<game>, <percentage>)` or whatever you want.

I talked a bit with @Viv9000 how this could be implemented in theory. The main thing is that while we don't have a backend, we have [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) which allows persistent storage in the current browser. This is how the current save state is implemented on the game websites.


FYI: @uu-semp/2025-data-team
