### PR TITLE
Team15/121/wardrobe container

### DIFF
--- a/team15/components/elements/buttons.js
+++ b/team15/components/elements/buttons.js
@@ -25,47 +25,45 @@ export const InfoButton = {
   `,
 };
 
-
 export const LevelButton = {
   name: "level-button",
-  props:{
+  props: {
     label: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
-  template:`
+  template: `
   <button class=big-buttons>{{ label }}</button>
   `,
-}
+};
 
 export const ClothingItemButton = {
-  name: "clothing-item-button", 
-  props:{
+  name: "clothing-item-button",
+  props: {
     label: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
-  template:`
+  template: `
     <button class=clothing-button>
       <img :src="label"  style="width: 50px;"></img>
     </button>
   `,
-}
-
+};
 
 export const CategoryClothingButton = {
-  name: "category-clothing-button", 
-  props:{
+  name: "category-clothing-button",
+  props: {
     label: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
-  template:`
+  template: `
     <button class=round-button>
       <img :src="label"  style="width: 40px;"></img>
     </button>
   `,
-}
+};

--- a/team15/components/elements/buttons.js
+++ b/team15/components/elements/buttons.js
@@ -38,3 +38,34 @@ export const LevelButton = {
   <button class=big-buttons>{{ label }}</button>
   `,
 }
+
+export const ClothingItemButton = {
+  name: "clothing-item-button", 
+  props:{
+    label: {
+      type: String,
+      required: true
+    }
+  },
+  template:`
+    <button class=clothing-button>
+      <img :src="label"  style="width: 50px;"></img>
+    </button>
+  `,
+}
+
+
+export const CategoryClothingButton = {
+  name: "category-clothing-button", 
+  props:{
+    label: {
+      type: String,
+      required: true
+    }
+  },
+  template:`
+    <button class=round-button>
+      <img :src="label"  style="width: 40px;"></img>
+    </button>
+  `,
+}

--- a/team15/components/elements/wardrobeContainer.js
+++ b/team15/components/elements/wardrobeContainer.js
@@ -1,0 +1,21 @@
+export const WardrobeContainer = {
+  name: "wardrobe-container",
+  template: `
+    <div class = "wardrobe">
+        <div class="container">
+            <button class="button-image">
+                img1  
+                <img src="../../../assets/furniture/chair.png"  style="width: 50px;"></img>
+            </button>
+            <button class="button-image">img2</button>
+            <button class="button-image">img3</button>
+            <button class="button-image">img4</button>
+            <button class="button-image">img5</button>
+            <button class="button-image">img6</button>
+            <button class="button-image">img7</button>
+            <button class="button-image">img8</button>
+            <button class="button-image">img9</button>
+        </div>
+    </div>
+      `,
+};

--- a/team15/components/elements/wardrobeContainer.js
+++ b/team15/components/elements/wardrobeContainer.js
@@ -2,20 +2,28 @@ export const WardrobeContainer = {
   name: "wardrobe-container",
   template: `
     <div class = "wardrobe">
+    
         <div class="container">
-            <button class="button-image">
-                img1  
-                <img src="../../../assets/furniture/chair.png"  style="width: 50px;"></img>
-            </button>
-            <button class="button-image">img2</button>
-            <button class="button-image">img3</button>
-            <button class="button-image">img4</button>
-            <button class="button-image">img5</button>
-            <button class="button-image">img6</button>
-            <button class="button-image">img7</button>
-            <button class="button-image">img8</button>
-            <button class="button-image">img9</button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
+            <clothing-item-button label = "../../../assets/furniture/chair.png"></clothing-item-button>
         </div>
+        
+        <div class=category-container>
+            <category-clothing-button label = "../../../assets/furniture/chair.png"></category-clothing-button>
+            <category-clothing-button label = "../../../assets/furniture/chair.png"></category-clothing-button>
+            <category-clothing-button label = "../../../assets/furniture/chair.png"></category-clothing-button>
+            <category-clothing-button label = "../../../assets/furniture/chair.png"></category-clothing-button>
+        </div>
+
     </div>
       `,
 };
+
+// Uses the chair image as placeholder!

--- a/team15/components/index.js
+++ b/team15/components/index.js
@@ -8,7 +8,9 @@ import {
   HowToPlayButton,
   InfoButton,
   GoBackButton,
-  LevelButton
+  LevelButton,
+  CategoryClothingButton,
+  ClothingItemButton,
 } from "./elements/buttons.js";
 import { WardrobeContainer } from "./elements/wardrobeContainer.js";
 
@@ -24,5 +26,7 @@ export default {
   GoBackButton,
   InfoButton,
   LevelButton,
-  WardrobeContainer
+  WardrobeContainer,
+  CategoryClothingButton,
+  ClothingItemButton
 };

--- a/team15/components/index.js
+++ b/team15/components/index.js
@@ -10,6 +10,7 @@ import {
   GoBackButton,
   LevelButton
 } from "./elements/buttons.js";
+import { WardrobeContainer } from "./elements/wardrobeContainer.js";
 
 
 export default {
@@ -22,5 +23,6 @@ export default {
   HowToPlayButton,
   GoBackButton,
   InfoButton,
-  LevelButton
+  LevelButton,
+  WardrobeContainer
 };

--- a/team15/components/index.js
+++ b/team15/components/index.js
@@ -14,7 +14,6 @@ import {
 } from "./elements/buttons.js";
 import { WardrobeContainer } from "./elements/wardrobeContainer.js";
 
-
 export default {
   StartView,
   HelpView,
@@ -28,5 +27,5 @@ export default {
   LevelButton,
   WardrobeContainer,
   CategoryClothingButton,
-  ClothingItemButton
+  ClothingItemButton,
 };

--- a/team15/components/styling/wardrobe.css
+++ b/team15/components/styling/wardrobe.css
@@ -6,8 +6,10 @@
   border-width: 10px;
   border-radius: 30px;
   border-color: #02b823;
-  height: 350px;
-  width: 400px;
+  height: 300px;
+  width: 350px;
+  float: right;
+  margin:20px;
 }
 
 .container {
@@ -17,18 +19,40 @@
   grid-template-rows: repeat(3, 1fr)
 }
 
-.button-image {
-  border: 2px dotted #02b823;
+.clothing-button {
+  border: 1px dotted #02b823;
   font-size: 30px;
   background-color: #ceffd7;
   text-align: center;
+  border-radius: 30px;
 }
 
-.button-image:hover {
-  transform: scale(1.05);
+.clothing-button:hover,.round-button:hover {
+  transform: scale(1.02);
   cursor: grab;
 }
 
-.button-image:active {
-  box-shadow: 0 0 10px #2d2d2d;
+.clothing-button:active, .round-button:active {
+  box-shadow: 0 0 2px #676767;
 } 
+
+
+.round-button{
+  width: 80px;
+  height:80px;
+  background-color: #ceffd7;
+  border:solid;
+  border-color:#02b823;
+  border-width:8px;
+  border-radius: 100%;
+}
+
+.category-container{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+
+#go-back-button{
+  margin-top:20px;
+}

--- a/team15/components/styling/wardrobe.css
+++ b/team15/components/styling/wardrobe.css
@@ -9,14 +9,14 @@
   height: 300px;
   width: 350px;
   float: right;
-  margin:20px;
+  margin: 20px;
 }
 
 .container {
   height: 100%;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr)
+  grid-template-rows: repeat(3, 1fr);
 }
 
 .clothing-button {
@@ -24,35 +24,32 @@
   font-size: 30px;
   background-color: #ceffd7;
   text-align: center;
-  border-radius: 30px;
+  border-radius: 40px;
 }
 
-.clothing-button:hover,.round-button:hover {
+.clothing-button:hover,
+.round-button:hover {
   transform: scale(1.02);
   cursor: grab;
 }
 
-.clothing-button:active, .round-button:active {
+.clothing-button:active,
+.round-button:active {
   box-shadow: 0 0 2px #676767;
-} 
+}
 
-
-.round-button{
+.round-button {
   width: 80px;
-  height:80px;
+  height: 80px;
   background-color: #ceffd7;
-  border:solid;
-  border-color:#02b823;
-  border-width:8px;
+  border: solid;
+  border-color: #02b823;
+  border-width: 8px;
   border-radius: 100%;
 }
 
-.category-container{
+.category-container {
+  margin-top: -15px;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-}
-
-
-#go-back-button{
-  margin-top:20px;
 }

--- a/team15/components/styling/wardrobe.css
+++ b/team15/components/styling/wardrobe.css
@@ -1,0 +1,34 @@
+/* Wardrobe specific styling */
+
+.wardrobe {
+  background-color: #ceffd7;
+  border: solid;
+  border-width: 10px;
+  border-radius: 30px;
+  border-color: #02b823;
+  height: 350px;
+  width: 400px;
+}
+
+.container {
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr)
+}
+
+.button-image {
+  border: 2px dotted #02b823;
+  font-size: 30px;
+  background-color: #ceffd7;
+  text-align: center;
+}
+
+.button-image:hover {
+  transform: scale(1.05);
+  cursor: grab;
+}
+
+.button-image:active {
+  box-shadow: 0 0 10px #2d2d2d;
+} 

--- a/team15/components/views/levelOneView.js
+++ b/team15/components/views/levelOneView.js
@@ -2,8 +2,8 @@ export const LevelOneView = {
     name: "level-one-view",
     props: ["switchTo"],
     template: `
-        <div>
-        <h1 class = "main-text">THIS IS THE LEVEL 1 VIEW</h1>
+        <div class=level-one-view>
+         <h1>THIS IS THE LEVEL 1 VIEW</h1>
         <wardrobe-container></wardrobe-container>    
         <div class = button-container> 
           <go-back-button @click="switchTo('ChooseLevelView')"></go-back-button>
@@ -11,6 +11,4 @@ export const LevelOneView = {
         </div>
       `,
   };
-  
-  
   

--- a/team15/components/views/levelOneView.js
+++ b/team15/components/views/levelOneView.js
@@ -3,10 +3,14 @@ export const LevelOneView = {
     props: ["switchTo"],
     template: `
         <div>
-        <h1 class = "main-text">THIS IS THE LEVEL 1 VIEW</h1>    
+        <h1 class = "main-text">THIS IS THE LEVEL 1 VIEW</h1>
+        <wardrobe-container></wardrobe-container>    
         <div class = button-container> 
           <go-back-button @click="switchTo('ChooseLevelView')"></go-back-button>
         </div>
         </div>
       `,
   };
+  
+  
+  

--- a/team15/components/views/levelOneView.js
+++ b/team15/components/views/levelOneView.js
@@ -1,14 +1,13 @@
 export const LevelOneView = {
-    name: "level-one-view",
-    props: ["switchTo"],
-    template: `
+  name: "level-one-view",
+  props: ["switchTo"],
+  template: `
         <div class=level-one-view>
-         <h1>THIS IS THE LEVEL 1 VIEW</h1>
-        <wardrobe-container></wardrobe-container>    
-        <div class = button-container> 
-          <go-back-button @click="switchTo('ChooseLevelView')"></go-back-button>
-        </div>
+          <h1>THIS IS THE LEVEL 1 VIEW</h1>
+          <wardrobe-container></wardrobe-container>    
+          <div class = button-container> 
+            <go-back-button @click="switchTo('ChooseLevelView')"></go-back-button>
+          </div>
         </div>
       `,
-  };
-  
+};

--- a/team15/index.css
+++ b/team15/index.css
@@ -86,3 +86,9 @@ body {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
   transition: 0.3s ease;
 }
+
+.level-one-view{
+  width:100%;
+  height:100%;
+  position:relative;
+}

--- a/team15/index.html
+++ b/team15/index.html
@@ -24,8 +24,10 @@ Owned by Team 15
 
     <!-- Site specific scripts and styles -->
     <link rel="stylesheet" href="index.css" />
+    <link rel="stylesheet" href="./components/styling/wardrobe.css">
     <script src="index.js" defer></script>
     <script type="module" src="app.js"></script>
+
   </head>
 
   <body>


### PR DESCRIPTION
Added a wardrobe container to Level 1 view. It features 3 new components, and a css script that goes together with the wardrobe container, so the global index.css script does not get to big. 

Right now the images are statically typed, i.e uses the same image locate within the repository, i.e not on the database. 
It also lacks any real function, beside the visual part. 

I have also used a file formatter so some parts have been changed due to "prettier" reasons. 

The image below is the new: Level 1 view. 

edit: also the dotted lines within the container is just there for visualisation of the grid, and will be removed at a later time.
<img width="820" height="617" alt="Skärmavbild 2025-09-30 kl  15 47 18" src="https://github.com/user-attachments/assets/d65366a1-a63c-47e3-94a6-20471775e540" />
