### PR TITLE
team12: remove about button from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ Owned by the Menu Team
             <img src="assets/main_menu/images/UU_logo.png" alt="Uppsala University Logo">
             <div>
                 <button class="header-btn">Language</button>
-                <button class="header-btn">About</button>
+                <!-- <button class="header-btn">About</button> --> <!-- Non functioning button: Can be used in the future to add an about page -->
                 <button class="header-btn" id="settings-btn">Settings</button>
             </div>
         </header>


### PR DESCRIPTION
Small PR that removes the about button from the header