### PR TITLE
Team 05: Fix asset path when page is rendered in a subdirectory like on GitHub Pages

### DIFF
--- a/team05/js/easy.js
+++ b/team05/js/easy.js
@@ -46,7 +46,7 @@ $(function () {
       // --- Create image boxes (in order, unchanged) ---
       words.forEach((item, index) => {
         const img = document.createElement("img");
-        img.src = "/" + item.image;
+        img.src = "../../" + item.image;
         img.classList.add("item");
         img.dataset.answer = item.swedish;
         img.dataset.index = index;

--- a/team05/js/hard.js
+++ b/team05/js/hard.js
@@ -195,7 +195,7 @@ function setupLevelUI() {
     if (staticIndices.has(vocabIndex)) {
       const staticInfo = levelData.staticVocabs.find(sv => sv.index === vocabIndex);
       const img = document.createElement('img');
-      img.src = '/' + fullVocab.img;
+      img.src = '../../' + fullVocab.img;
       img.className = 'static-item';
       img.style.width = `${vocab.maxWidth * smallestRoomDim}px`;
       img.onload = () => {
@@ -210,7 +210,7 @@ function setupLevelUI() {
       const wrapper = document.createElement('div');
       wrapper.className = 'draggable-item-wrapper';
       const img = document.createElement('img');
-      img.src = '/' + fullVocab.img;
+      img.src = '../../' + fullVocab.img;
       img.className = 'draggable-item';
       img.dataset.vocabIndex = vocabIndex;
       img.draggable = true;

--- a/team05/js/main_menu.js
+++ b/team05/js/main_menu.js
@@ -110,7 +110,7 @@ $(function () {
       if (vocab && vocab.img && vocab.img_copyright) {
         creditsHtml += `
           <li>
-            <img src="/${vocab.img}" alt="${vocab.en}">
+            <img src="../${vocab.img}" alt="${vocab.en}">
             <strong>${vocab.en}</strong>
             <div class="copyright-text">${vocab.img_copyright}</div>
           </li>

--- a/team05/js/medium.js
+++ b/team05/js/medium.js
@@ -76,7 +76,7 @@ $(function() {
         en: vocab.en || "",
         sv: vocab.sv || "",
         sv_pl: vocab.sv_pl || "",
-        img: "/" + vocab.img || "",
+        img: "../../" + vocab.img || "",
         article: vocab.article || "",
       });
     }


### PR DESCRIPTION
From the last level integration PR (https://github.com/uu-semp/swedish-learning-app-2025/pull/215) the fetching of image assets breaks as the page is rendered in a subdirectory. This PR fixes should fix this by using relative paths, but I can't be for completely sure until it is merged.