### PR TITLE
team 05: fix path for json level descriptor when in subdirectory

### DIFF
--- a/team05/js/hard.js
+++ b/team05/js/hard.js
@@ -147,7 +147,7 @@ async function loadLevel(levelNumber) {
   }
 
   try {
-    const indexResponse = await fetch('/team05/assets/level-descriptors/hard/index.json');
+    const indexResponse = await fetch('../assets/level-descriptors/hard/index.json');
     const levelIndex = await indexResponse.json();
 
     const levelConfig = levelIndex.find(l => l.level === levelNumber);


### PR DESCRIPTION
This also fixes the path for the JSON level-descriptors in subdirectory: related pr: (https://github.com/uu-semp/swedish-learning-app-2025/pull/216)