### PR TITLE
team 05: fix path for json level descriptor index when in subdirectory

### DIFF
--- a/team05/assets/level-descriptors/hard/index.json
+++ b/team05/assets/level-descriptors/hard/index.json
@@ -2,19 +2,19 @@
   {
     "level": 7,
     "include": [
-      "/team05/assets/level-descriptors/hard/level7-var1.json"
+      "../assets/level-descriptors/hard/level7-var1.json"
     ]
   },
   {
     "level": 8,
     "include": [
-      "/team05/assets/level-descriptors/hard/level8-var1.json"
+      "../assets/level-descriptors/hard/level8-var1.json"
     ]
   },
   {
     "level": 9,
     "include": [
-      "/team05/assets/level-descriptors/hard/level9-var1.json"
+      "../assets/level-descriptors/hard/level9-var1.json"
     ]
   }
 ]


### PR DESCRIPTION
This fixes the path for the JSON level-descriptors index when served in subdirectory: related pr: (https://github.com/uu-semp/swedish-learning-app-2025/pull/216).

It is annoying that you cant seem to test this without merging 😢